### PR TITLE
Updated angular demo, fixed the js to primitive function on ios for b…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,13 +3,21 @@
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
-  "configurations": [
-    {
+  "configurations": [{
       "name": "Launch on iOS",
       "type": "nativescript",
       "request": "launch",
       "platform": "ios",
       "appRoot": "${workspaceRoot}/demo",
+      "sourceMaps": true,
+      "watch": true
+    },
+    {
+      "name": "Launch on iOS Angular",
+      "type": "nativescript",
+      "request": "launch",
+      "platform": "ios",
+      "appRoot": "${workspaceRoot}/demo-angular",
       "sourceMaps": true,
       "watch": true
     },

--- a/demo-angular/nativescript.config.ts
+++ b/demo-angular/nativescript.config.ts
@@ -1,0 +1,11 @@
+import { NativeScriptConfig } from '@nativescript/core';
+
+export default {
+  id: 'org.nativescript.chartsdemoangular',
+  appResourcesPath: 'App_Resources',
+  android: {
+    v8Flags: '--expose_gc',
+    markingMode: 'none',
+  },
+  appPath: 'src',
+} as NativeScriptConfig;

--- a/demo-angular/nsconfig.json
+++ b/demo-angular/nsconfig.json
@@ -1,4 +1,0 @@
-{
-  "appResourcesPath": "App_Resources",
-  "appPath": "src"
-}

--- a/demo-angular/package.json
+++ b/demo-angular/package.json
@@ -1,20 +1,12 @@
 {
-  "nativescript": {
-    "id": "org.nativescript.chartsdemoangular",
-    "tns-android": {
-      "version": "6.5.3"
-    },
-    "tns-ios": {
-      "version": "6.5.2"
-    }
-  },
   "description": "NativeScript Application",
   "license": "SEE LICENSE IN <your-license-filename>",
   "repository": "<fill-your-repository-here>",
   "scripts": {
     "clean": "npx rimraf hooks node_modules package-lock.json platforms",
     "ngcc": "ngcc --properties es2015 module main --first-only",
-    "postinstall": "npm run ngcc"
+    "postinstall": "npm run ngcc",
+    "ios": "ns clean && ns run ios"
   },
   "dependencies": {
     "@angular/animations": "~10.0.0",
@@ -26,7 +18,7 @@
     "@angular/platform-browser-dynamic": "~10.0.0",
     "@angular/router": "~10.0.0",
     "@nativescript/angular": "rc",
-    "@nativescript/core": "rc",
+    "@nativescript/core": "~7.0.0",
     "@nativescript/theme": "~2.3.0",
     "@nativescript/ui-charts": "file:../src/nativescript-ui-charts.tgz",
     "reflect-metadata": "~0.1.12",
@@ -35,10 +27,13 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~10.0.0",
-    "@nativescript/types": "rc",
+    "@nativescript/android": "7.0.0",
+    "@nativescript/ios": "7.0.1",
+    "@nativescript/types": "~7.0.0",
     "@nativescript/webpack": "rc",
     "@ngtools/webpack": "~10.0.0",
     "typescript": "~3.9.0"
   },
-  "readme": "NativeScript Application"
+  "readme": "NativeScript Application",
+  "main": "main.js"
 }

--- a/demo-angular/src/package.json
+++ b/demo-angular/src/package.json
@@ -1,7 +1,0 @@
-{
-  "main": "main.js",
-  "android": {
-    "v8Flags": "--expose_gc",
-    "markingMode": "none"
-  }
-}

--- a/demo-angular/tsconfig.json
+++ b/demo-angular/tsconfig.json
@@ -1,22 +1,26 @@
 {
   "compilerOptions": {
-      "module": "ESNext",
-      "target": "es2015",
-      "moduleResolution": "node",
-      "experimentalDecorators": true,
-      "emitDecoratorMetadata": true,
-      "noEmitHelpers": true,
-      "noEmitOnError": true,
-      "skipLibCheck": true,
-      "lib": [
-        "es2018", "es2017", "dom", "es6"
-      ],
-      "baseUrl": ".",
-      "paths": {
-          "~/*": [
-              "app/*"
-          ]
-      }
+    "module": "esnext",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "noEmitHelpers": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true,
+    "lib": [
+      "es2018",
+      "es2017",
+      "dom",
+      "es6"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "app/*"
+      ]
+    },
+    "removeComments": false
   },
   "include": [
     "references.d.ts",
@@ -26,8 +30,8 @@
     "./src/main.ts"
   ],
   "exclude": [
-      "node_modules",
-      "platforms",
-      "e2e"
+    "node_modules",
+    "platforms",
+    "e2e"
   ]
 }

--- a/demo-angular/tsconfig.tns.json
+++ b/demo-angular/tsconfig.tns.json
@@ -1,7 +1,0 @@
-{
-    "extends": "./tsconfig",
-    "compilerOptions": {
-        "module": "ESNext",
-        "moduleResolution": "node"
-    }
-}

--- a/src/options-handlers/helpers/helpers.ios.ts
+++ b/src/options-handlers/helpers/helpers.ios.ts
@@ -14,6 +14,7 @@ export function convertJSArrayToNative(array) {
 
 export function fromJSToNativePrimitive(value) {
   // stub
+  if (typeof (value) === 'boolean') return value ? 1 : 0;
   return value;
 }
 
@@ -34,7 +35,7 @@ export function toArrayListRecursive(arr) {
 
 export function colorToString(color: any) {
   const c = new Color(color);
-  return `rgba(${c.r}, ${c.g}, ${c.b}, ${c.a/255})`;
+  return `rgba(${c.r}, ${c.g}, ${c.b}, ${c.a / 255})`;
 }
 
 export function toHIColor(color) {
@@ -47,14 +48,14 @@ export function toHIColor(color) {
         const stops = c.stops.map((stop, index) => [index, colorToString(stop)]);
         const g = c.radialGradient;
         colorArray.push(new HIColor({
-          radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ["cx", "cy", "r"]), 
+          radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ["cx", "cy", "r"]),
           stops: stops
         }));
       } else if (c.linearGradient && c.stops) {
         const stops = c.stops.map((stop, index) => [index, colorToString(stop)]);
         const g = c.linearGradient;
-        colorArray.push(new HIColor({ 
-          linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ["x1", "y1", "x2", "y2"]), 
+        colorArray.push(new HIColor({
+          linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ["x1", "y1", "x2", "y2"]),
           stops: stops
         }));
       } else {
@@ -68,15 +69,15 @@ export function toHIColor(color) {
     if (color.radialGradient && color.stops) {
       const stops = color.stops.map((stop, index) => [index, colorToString(stop)]);
       const g = color.radialGradient;
-      return new HIColor({ 
-        radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ["cx", "cy", "r"]), 
+      return new HIColor({
+        radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ["cx", "cy", "r"]),
         stops: stops
       });
     } else if (color.linearGradient && color.stops) {
       const stops = color.stops.map((stop, index) => [index, colorToString(stop)]);
       const g = color.linearGradient;
-      return new HIColor({ 
-        linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ["x1", "y1", "x2", "y2"]), 
+      return new HIColor({
+        linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ["x1", "y1", "x2", "y2"]),
         stops: stops
       });
     } else {

--- a/src/package.json
+++ b/src/package.json
@@ -58,15 +58,15 @@
 	"homepage": "https://github.com/NativeScript/nativescript-ui-charts",
 	"devDependencies": {
 		"@nativescript/core": "rc",
+		"@nativescript/types": "rc",
 		"@nativescript/webpack": "~2.1.0",
 		"nativescript-vue": "^2.7.0",
 		"prompt": "^1.0.0",
 		"rimraf": "^3.0.2",
 		"semver": "^7.3.2",
-		"@nativescript/types": "rc",
-		"tslint": "^6.1.2",
 		"ts-node": "^9.0.0",
-		"ts-patch": "~1.3.0",
+		"ts-patch": "^1.3.0",
+		"tslint": "^6.1.2",
 		"typescript": "~3.9.0"
 	},
 	"bootstrapper": "nativescript-plugin-seed"


### PR DESCRIPTION
## What is the current behavior?
1. The angular demo app won't build and run.
2. When running the angular demo app on an iPhone, or another app with the plugin installed, the app crashes when trying to view the Basic Line Chart (async data).

## What is the new behavior?
1. Updated the angular demo app to run on ios 14 and xcode 12.
2. The fromJSToNativePrimitive(value) helper function wasn't translating booleans into numbers, which is expected by the api, causing the app to crash on iPhones. I've updated that function to return a number for booleans which prevents the app from crashing.

Fixes #5

