### PR TITLE
Added support for HiZones

### DIFF
--- a/src/options-handlers/helpers/_helpers.common.d.ts
+++ b/src/options-handlers/helpers/_helpers.common.d.ts
@@ -93,6 +93,7 @@ export declare const typesMap: {
     HIXAxis: (options: any) => java.util.ArrayList<any>;
     HIYAxis: (options: any) => java.util.ArrayList<any>;
     HIZAxis: (options: any) => java.util.ArrayList<any>;
+    HIZones: (options: any) => java.util.ArrayList<any>;
     HIFrame: (options: any) => any;
     HIBack: (options: any) => any;
     HIBottom: (options: any) => any;

--- a/src/options-handlers/helpers/_helpers.common.ts
+++ b/src/options-handlers/helpers/_helpers.common.ts
@@ -28,6 +28,7 @@ import { tooltipHandler } from "../tooltip/tooltip-handler";
 import { xAxisHandler } from "../xAxis/xAxis-handler";
 import { yAxisHandler } from "../yAxis/yAxis-handler";
 import { zAxisHandler } from "../zAxis/zAxis-handler";
+import { zonesHandler } from "../zones/zones-handler";
 import { backHandler } from '../frame/back/back-handler';
 import { bottomHandler } from '../frame/bottom/bottom-handler';
 import { frontHandler } from '../frame/front/front-handler';
@@ -211,6 +212,7 @@ export const typesMap = {
   'HIXAxis': (options) => xAxisHandler(options),
   'HIYAxis': (options) => yAxisHandler(options),
   'HIZAxis': (options) => zAxisHandler(options),
+  'HIZones': (options) => zonesHandler(options),
 
   // Frame handlers
   'HIFrame': (options) => frameHandler(options),

--- a/src/options-handlers/zones/zones-handler.d.ts
+++ b/src/options-handlers/zones/zones-handler.d.ts
@@ -1,0 +1,1 @@
+export declare function zonesHandler(zonesOptions: any): java.util.ArrayList<any>;

--- a/src/options-handlers/zones/zones-handler.ts
+++ b/src/options-handlers/zones/zones-handler.ts
@@ -1,0 +1,26 @@
+import { isAndroid } from "@nativescript/core";
+import { convertJSArrayToNative, optionsBuilder } from "../helpers/helpers";
+
+export function zonesHandler(zonesOptions) {
+  const zones = isAndroid ? new com.highsoft.highcharts.common.hichartsclasses.HIZones() : new HIZones();
+
+  const zonesSchema = {
+    className: 'string',
+    color: 'HIColor',
+    dashStyle: 'string',
+    fillColor: 'HIColor',
+    from: 'number',
+    marker: 'HIMarker',
+    to: 'number',
+    value: 'number'
+  };
+
+  let zonesArray = [];
+  if (zonesOptions instanceof Array) {
+    zonesArray = zonesOptions.map(zoneOpts => {
+      return optionsBuilder(zonesSchema, zoneOpts, zones);
+    });
+  }
+
+  return convertJSArrayToNative(zonesArray);
+}


### PR DESCRIPTION
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When trying to use zones ([Highcharts API](https://api.highcharts.com/highcharts/plotOptions.column.zones); [Example](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/series/color-zones-simple/)) The configuration is not affecting anything  in the chart and `HiZones are not implemented` is shown in the console.

## What is the new behavior?
<!-- Describe the changes. -->
Added the HiZones implementation to the library.

I hope that the mapper I did is correct, I added the properties I saw listed in the [Android Highcharts API](https://api.highcharts.com/android/highcharts/com/highsoft/highcharts/common/hichartsclasses/HIZAxis.html).

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

