### PR TITLE
fixes bug #17

### DIFF
--- a/demo-angular/package.json
+++ b/demo-angular/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@angular/compiler-cli": "~10.0.0",
     "@nativescript/android": "7.0.1",
-    "@nativescript/ios": "^8.0.0",
+    "@nativescript/ios": "rc",
     "@nativescript/types": "^7.0.0",
     "@nativescript/webpack": "~4.1.0",
     "@ngtools/webpack": "~10.0.0",

--- a/src/options-handlers/helpers/helpers.ios.ts
+++ b/src/options-handlers/helpers/helpers.ios.ts
@@ -1,20 +1,19 @@
-import { Color } from "@nativescript/core";
-import { typesMap as _typesMap } from "./_helpers.common";
+import { Color } from '@nativescript/core';
+import { typesMap as _typesMap } from './_helpers.common';
 
 const typesMap = Object.assign({}, _typesMap, {
-  'number': (options) => fromJSToNativePrimitive(options),
-  'boolean': (options) => fromJSToNativePrimitive(options),
-  'Array': (options) => convertJSArrayToNative(options),
-  'HIColor': (options) => toHIColor(options),
-})
+  number: (options) => fromJSToNativePrimitive(options),
+  boolean: (options) => fromJSToNativePrimitive(options),
+  Array: (options) => convertJSArrayToNative(options),
+  HIColor: (options) => toHIColor(options),
+});
 
 export function convertJSArrayToNative(array) {
-  return new NSArray({ array: array });;
+  return new NSArray({ array: array });
 }
 
 export function fromJSToNativePrimitive(value) {
   // stub
-  if (typeof (value) === 'boolean') return value ? 1 : 0;
   return value;
 }
 
@@ -35,7 +34,7 @@ export function toArrayListRecursive(arr) {
 
 export function colorToString(color: any) {
   const c = new Color(color);
-  return `rgba(${c.r}, ${c.g}, ${c.b}, ${c.a/255})`;
+  return `rgba(${c.r}, ${c.g}, ${c.b}, ${c.a / 255})`;
 }
 
 export function toHIColor(color) {
@@ -47,17 +46,24 @@ export function toHIColor(color) {
       if (c.radialGradient && c.stops) {
         const stops = c.stops.map((stop, index) => [index, colorToString(stop)]);
         const g = c.radialGradient;
-        colorArray.push(new HIColor({
-          radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ["cx", "cy", "r"]),
-          stops: stops
-        }));
+        colorArray.push(
+          new HIColor({
+            radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ['cx', 'cy', 'r']),
+            stops: stops,
+          })
+        );
       } else if (c.linearGradient && c.stops) {
         const stops = c.stops.map((stop, index) => [index, colorToString(stop)]);
         const g = c.linearGradient;
-        colorArray.push(new HIColor({
-          linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ["x1", "y1", "x2", "y2"]),
-          stops: stops
-        }));
+        colorArray.push(
+          new HIColor({
+            linearGradient: NSDictionary.dictionaryWithObjectsForKeys(
+              [g.x1, g.y1, g.x2, g.y2],
+              ['x1', 'y1', 'x2', 'y2']
+            ),
+            stops: stops,
+          })
+        );
       } else {
         const _c = new Color(c);
         colorArray.push(new HIColor(_c.ios) as any);
@@ -70,15 +76,15 @@ export function toHIColor(color) {
       const stops = color.stops.map((stop, index) => [index, colorToString(stop)]);
       const g = color.radialGradient;
       return new HIColor({
-        radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ["cx", "cy", "r"]),
-        stops: stops
+        radialGradient: NSDictionary.dictionaryWithObjectsForKeys([g.cx, g.cy, g.r], ['cx', 'cy', 'r']),
+        stops: stops,
       });
     } else if (color.linearGradient && color.stops) {
       const stops = color.stops.map((stop, index) => [index, colorToString(stop)]);
       const g = color.linearGradient;
       return new HIColor({
-        linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ["x1", "y1", "x2", "y2"]),
-        stops: stops
+        linearGradient: NSDictionary.dictionaryWithObjectsForKeys([g.x1, g.y1, g.x2, g.y2], ['x1', 'y1', 'x2', 'y2']),
+        stops: stops,
       });
     } else {
       const c = new Color(color);
@@ -105,4 +111,3 @@ export function optionsBuilder(schema, options, containerObject) {
 
   return containerObject;
 }
-


### PR DESCRIPTION

## What is the current behavior?
see bug description. It was not possible to disable the exporting button on ios given the new ios runtime

## What is the new behavior?
exporting button is now correctly disabled. Required changing one line of code in plugin in order for boolean values to get correctly mapped to native NSNumber boolean valued objects.
Furthermore demo app now requires rc version of runtime which adds the required underlaying bugfix.

Fixes/Implements/Closes #[Issue Number].
fixes bug #17

BREAKING CHANGES:
no breaking changes

Migration steps:
no migration required


