### PR TITLE
updateChartContent working again

### DIFF
--- a/src-angular/index.ts
+++ b/src-angular/index.ts
@@ -7,7 +7,7 @@ registerElement('UIChartsView', () => UIChartsView);
 // the actual extended class implementing the bugfix
 @Directive({
   // tslint:disable-next-line: directive-selector
-  selector: 'UIChartsView'
+  selector: 'UIChartsView',
 })
 export class UIChartsViewDirective implements OnChanges, OnDestroy {
   private _uiChartsView: UIChartsView = null;
@@ -63,7 +63,7 @@ export class UIChartsViewDirective implements OnChanges, OnDestroy {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   private setChartViewOptions() {
     if (this.options !== null && this.options !== undefined) {
-      if (!this._uiChartsView._chartInitialized) {
+      if (!(<any>this._uiChartsView)._chartInitialized) {
         this._uiChartsView.setOptions(this.options);
       } else {
         if (this.updateChartContent) {
@@ -78,6 +78,6 @@ export class UIChartsViewDirective implements OnChanges, OnDestroy {
 
 @NgModule({
   declarations: [UIChartsViewDirective],
-  exports: [UIChartsViewDirective]
+  exports: [UIChartsViewDirective],
 })
 export class UIChartsViewModule {}

--- a/src/package.json
+++ b/src/package.json
@@ -20,6 +20,7 @@
     "build.angular": "cd ../src-angular && npm run build",
     "tslint": "cd .. && tslint \"**/*.ts\" --config tslint.json --exclude \"**/node_modules/**\"",
     "ci.tslint": "npm i && tslint '**/*.ts' --config '../tslint.json' --exclude '**/node_modules/**' --exclude '**/platforms/**'",
+    "src-angular.reset": "cd ../src-angular && npx rimraf node_modules package-lock.json",
     "demo.ios": "tsc && npm i && cd ../demo && tns run ios",
     "demo.android": "npm i && cd ../demo && tns run android",
     "demo.reset": "cd ../demo && npx rimraf -- hooks node_modules platforms package-lock.json",
@@ -27,7 +28,7 @@
     "demo-angular.android": "npm i && cd ../demo-angular && tns run android --no-hmr",
     "demo-angular.reset": "cd ../demo-angular && npx rimraf -- hooks node_modules platforms package-lock.json",
     "plugin.prepare": "npm run build && cd ../demo && tns plugin remove @nativescript/ui-charts && tns plugin add ../src && cd ../demo-angular && tns plugin remove @nativescript/ui-charts && tns plugin add ../src",
-    "clean": "npm run demo.reset && npm run demo-angular.reset && npx rimraf node_modules package-lock.json angular && npm run tsc"
+    "clean": "npm run src-angular.reset && npm run demo.reset && npm run demo-angular.reset && npx rimraf node_modules package-lock.json angular && npm run tsc"
   },
   "keywords": [
     "NativeScript",

--- a/src/ui-charts.android.d.ts
+++ b/src/ui-charts.android.d.ts
@@ -1,5 +1,6 @@
 import { UIChartsViewBase } from './ui-charts.common';
 export declare class UIChartsView extends UIChartsViewBase {
+    _chartInitialized: boolean;
     customLayoutChangeListener: any;
     chartHeight: any;
     chartWidth: any;

--- a/src/ui-charts.android.ts
+++ b/src/ui-charts.android.ts
@@ -4,6 +4,7 @@ import { Application } from '@nativescript/core';
 import { langHandler } from './options-handlers/lang/lang-handler';
 
 export class UIChartsView extends UIChartsViewBase {
+  public _chartInitialized: boolean = false;
   public customLayoutChangeListener;
   public chartHeight;
   public chartWidth;
@@ -61,6 +62,7 @@ export class UIChartsView extends UIChartsViewBase {
   }
 
   public disposeNativeView() {
+    this._chartInitialized = false;
     Application.off('orientationChanged', (<any>this)._orientationHandler);
     super.disposeNativeView();
   }
@@ -79,6 +81,8 @@ export class UIChartsView extends UIChartsViewBase {
     const hiOptions = optionsHandler(this.options);
     if (this.nativeView) {
       this.nativeView.setOptions(hiOptions);
+      this._chartInitialized = true;
+      this.nativeView.reload();
     }
   }
 

--- a/src/ui-charts.ios.d.ts
+++ b/src/ui-charts.ios.d.ts
@@ -1,5 +1,6 @@
 import { UIChartsViewBase } from './ui-charts.common';
 export declare class UIChartsView extends UIChartsViewBase {
+    _chartInitialized: boolean;
     private _delegate;
     onLoaded(): void;
     createNativeView(): any;

--- a/src/ui-charts.ios.ts
+++ b/src/ui-charts.ios.ts
@@ -3,6 +3,7 @@ import { optionsHandler } from './options-handlers/options-handler';
 import { langHandler } from './options-handlers/lang/lang-handler';
 
 export class UIChartsView extends UIChartsViewBase {
+  public _chartInitialized: boolean = false;
   private _delegate: HighchartsViewDelegateImpl;
   public onLoaded() {
     super.onLoaded();
@@ -23,6 +24,7 @@ export class UIChartsView extends UIChartsViewBase {
   }
 
   public disposeNativeView() {
+    this._chartInitialized = false;
     super.disposeNativeView();
   }
 
@@ -43,6 +45,8 @@ export class UIChartsView extends UIChartsViewBase {
     const hiOptions = optionsHandler(this.options);
     if (this.nativeView) {
       this.nativeView.options = hiOptions;
+      this._chartInitialized = true;
+      this.nativeView.reload();
     }
   }
 


### PR DESCRIPTION
@shiv19 as discussed today, setChartViewOptions is now working again. I was able to build for ARM64 with the new cocoapod. For me the angular and native demo are working. I realized that it was pulling 9.3.1. 