### PR TITLE
bugfix for setting lang opts via angular bindings

### DIFF
--- a/src-angular/index.ts
+++ b/src-angular/index.ts
@@ -45,7 +45,7 @@ export class UIChartsViewDirective implements OnChanges, OnDestroy {
             break;
           case 'langOptions':
             if (changes.langOptions.currentValue) {
-              this.langOptions = changes.options.currentValue;
+              this.langOptions = changes.langOptions.currentValue;
               if (this._chartViewLoaded) {
                 this._uiChartsView.setLangOptions(this.langOptions);
               }


### PR DESCRIPTION
@shiv19 This is a little bugfix to correctly set the language options via the angular bindings.

Please note, seems like due to some recent migration of the demos I at least cannot build the angular demo anymore, seems to not find the typings. I could not find out what is broken with the demo. However, the bugfix I provide with this PR works. Tested with own app.