### PR TITLE
fix annotations: set iOS pod version to 9.2.2

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/ui-charts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Nativescript wrapper for Highcharts iOS and Android SDKs",
   "main": "ui-charts",
   "typings": "index.d.ts",

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Highcharts', '~> 9.3'
+pod 'Highcharts', '9.2.2'


### PR DESCRIPTION
## What is the current behavior?
Chart annotations are not visible on the chart (and/or not the correct position) since updating to HighCharts iOS library v9.3.0.

## What is the new behavior?
After setting HighCharts iOS library back to v9.2.2, the annotations are working again as it previously did, and showing up in the right position.
